### PR TITLE
added custom regex to fix routing

### DIFF
--- a/packages/grid/helm/syft/templates/global/ingress.yaml
+++ b/packages/grid/helm/syft/templates/global/ingress.yaml
@@ -52,28 +52,21 @@ spec:
             name: backend
             port:
               number: 80
-        path: /api
+        path: /()(api)(.*)
         pathType: Prefix
       - backend:
           service:
             name: backend
             port:
               number: 80
-        path: /docs
-        pathType: Prefix
-      - backend:
-          service:
-            name: backend
-            port:
-              number: 80
-        path: /redoc
+        path: /()(docs|redoc)
         pathType: Prefix
       - backend:
           service:
             name: seaweedfs
             port:
               number: 8333
-        path: /blob(/|$)(.*)
+        path: /(blob/)(.*)
         pathType: ImplementationSpecific
   {{- end }}
   {{- if .Values.ingress.tls.enabled }}

--- a/packages/grid/helm/syft/values.yaml
+++ b/packages/grid/helm/syft/values.yaml
@@ -205,6 +205,12 @@ ingress:
   hostname: null # do not make this localhost
   annotations: null
 
+  # When using nginx ingress controller without internal proxy , re-enable this
+  # annotations:
+  #   nginx.ingress.kubernetes.io/use-regex: "true"
+  #   nginx.ingress.kubernetes.io/rewrite-target: /$2$3
+  #   nginx.ingress.kubernetes.io/upstream-vhost: "$service_name:$service_port"
+
   tls:
     enabled: false
     secretName: null


### PR DESCRIPTION
Since the nginx url re-write applies to all the paths in the ingress resource.

The paths of /api/v2/metadata(or generally /api/*) are re-written to / (root url)

This PR fixes the same.

Pending:

This still needs testing as it fails some of the seaweedfs tests.